### PR TITLE
Add Spectra as submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spectra"]
+	path = spectra
+	url = https://github.com/yixuan/spectra.git

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,12 +54,6 @@ install:
   - cmake .. && make && make test && sudo make install
 
 
-  # Install Spectra
-  - cd /usr/local/
-  - sudo git clone https://github.com/yixuan/spectra.git
-
-
-
 # Run the build script
 script:
   - cd /home/travis/build/GQCG/numopt

--- a/README.md
+++ b/README.md
@@ -9,8 +9,6 @@ A C++ library for performing numerical optimization.
 ## Dependencies
 [![Boost Dependency](https://img.shields.io/badge/Boost-1.65.1+-000000.svg)](www.boost.org)
 [![Eigen3 Dependency](https://img.shields.io/badge/Eigen-3.3.4+-000000.svg)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-[![Spectra Dependency](https://img.shields.io/badge/Spectra-0.6.1+-000000.svg)](https://github.com/yixuan/spectra/)
-
 [![cpputil Dependency](https://img.shields.io/badge/cpputil-1.2.2+-blue.svg)](https://github.com/GQCG/cpputil)
 
 
@@ -19,7 +17,7 @@ A C++ library for performing numerical optimization.
 To install this library:
 1. clone the master branch, which contains the latest release:
 
-        git clone https://github.com/GQCG/numopt.git --branch master --single-branch
+        git clone https://github.com/GQCG/numopt.git --branch master --single-branch --recurse-submodules
         cd numopt
 
 2. perform an out-of-source cmake build:

--- a/cmake/FindSpectra.cmake
+++ b/cmake/FindSpectra.cmake
@@ -1,7 +1,5 @@
 # FindSpectra.cmake. Find<package>.cmake-template from (https://cmake.org/Wiki/CMake:How_To_Find_Libraries#Writing_find_modules).
 
-# For the moment, only an installation of Spectra inside /usr/local is supported.
-
 # Try to find Spectra
 # Once done, this will define
 #  Spectra_FOUND            spectra is available on the system
@@ -9,12 +7,10 @@
 
 # Since it's a header-only library, the include directories are enough.
 
-
-# For the moment, only an installation in /usr/local is supported
 find_path(SPECTRA_PREFIX README.md HINTS ${CMAKE_SOURCE_DIR}/spectra /usr/local/spectra)
 
 if("${SPECTRA_PREFIX}" STREQUAL "SPECTRA_PREFIX-NOTFOUND")
-    message(WARNING "Spectra was not found in location /usr/local/.")
+    message(WARNING "Spectra was not found.")
 else()
     # If found, we let the user know that Spectra was found
     message(STATUS "Spectra was found at ${SPECTRA_PREFIX}")

--- a/cmake/FindSpectra.cmake
+++ b/cmake/FindSpectra.cmake
@@ -11,7 +11,7 @@
 
 
 # For the moment, only an installation in /usr/local is supported
-find_path(SPECTRA_PREFIX README.md HINTS /usr/local/spectra)
+find_path(SPECTRA_PREFIX README.md HINTS ${CMAKE_SOURCE_DIR}/spectra /usr/local/spectra)
 
 if("${SPECTRA_PREFIX}" STREQUAL "SPECTRA_PREFIX-NOTFOUND")
     message(WARNING "Spectra was not found in location /usr/local/.")


### PR DESCRIPTION
This eases installation procedures by reducing the explicit dependency on Spectra to a submodule import.