### PR TITLE
Fix non-MKL compilation with icpc

### DIFF
--- a/src/DavidsonSolver.cpp
+++ b/src/DavidsonSolver.cpp
@@ -179,6 +179,8 @@ void DavidsonSolver::solve() {
 
                 this->eigenpairs[i] = numopt::eigenproblem::Eigenpair(eigenvalue, eigenvector);
             }
+	
+	    break;  // because we don't want the flow to continue to after the if-statement
         }
 
         else {  // if not yet converged


### PR DESCRIPTION
There was a bug in the DavidsonSolver, which happened after the algorithm had already converged: an early break feels like the correct solution.